### PR TITLE
Views/Drops: Implement Prev/Next functionality

### DIFF
--- a/themes/default/media/css/styles.css
+++ b/themes/default/media/css/styles.css
@@ -2070,6 +2070,24 @@ article.modal div.search ul.dual-buttons {
      left: 10px; */
   
   }
+  .button-prev div {
+    float: left;
+    width: 0;
+    height: 0;
+    border-top: 19px solid transparent;
+    border-bottom: 19px solid transparent;
+    border-right: 30px solid #EAF3F5;
+    margin: 0 5px;
+  }
+  .button-next div {
+    float: right;
+    width: 0;
+    height: 0;
+    border-top: 19px solid transparent;
+    border-bottom: 19px solid transparent;
+    border-left: 30px solid #EAF3F5;
+    margin: 0 5px;
+  }
   /* --------------------------- BUCKET */
   section.rundown {
     display: block;

--- a/themes/default/views/pages/drop/drops.php
+++ b/themes/default/views/pages/drop/drops.php
@@ -196,7 +196,7 @@
 
 	<div class="base">
 		<section class="drop-source cf">
-			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %> <a href="#" class="button-prev">Prev</a> <a href="#" class="button-next">Next</a></p>
+			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %><% if ($('#content > .river').length > 0) { %> <a href="#" class="button-prev">Prev</a> <a href="#" class="button-next">Next</a><% } %></p>
 			<a href="#" class="avatar-wrap"><img src="<%= identity_avatar %>" /></a>
 			<div class="byline">
 				<h2><%= identity_name %></h2>

--- a/themes/default/views/pages/drop/drops.php
+++ b/themes/default/views/pages/drop/drops.php
@@ -196,7 +196,7 @@
 
 	<div class="base">
 		<section class="drop-source cf">
-			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %><% if ($('#content > .river').length > 0) { %> <a href="#" class="button-prev">Prev</a> <a href="#" class="button-next">Next</a><% } %></p>
+			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %></p>
 			<a href="#" class="avatar-wrap"><img src="<%= identity_avatar %>" /></a>
 			<div class="byline">
 				<h2><%= identity_name %></h2>
@@ -209,6 +209,9 @@
 			<%= droplet_title %>
 		</div>
 		<div class="drop-actions cf">
+			<% if ($('#content > .river').length > 0) { %>
+			<a href="#" class="button-prev"><div></div></a>
+			<% } %>
 			<?php if ( ! $anonymous): ?>
 				<ul class="dual-buttons score-drop">
 					<li class="button-white like <%= parseInt(user_score) == 1 ? 'scored' : ''  %>">
@@ -218,6 +221,11 @@
 						<a href="#"><span class="icon"></span></a>
 					</li>
 				</ul>
+			<?php endif; ?>
+				<% if ($('#content > .river').length > 0) { %>
+				<a href="#" class="button-next"><div></div></a>
+				<% } %>
+			<?php if ( ! $anonymous): ?>
 				<ul class="dual-buttons move-drop">
 					<li class="button-blue share">
 						<a href="#" class="modal-trigger"><span class="icon"></span></a>

--- a/themes/default/views/pages/drop/drops.php
+++ b/themes/default/views/pages/drop/drops.php
@@ -196,7 +196,7 @@
 
 	<div class="base">
 		<section class="drop-source cf">
-			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %></p>
+			<p class="metadata"><%= new Date(droplet_date_pub).toLocaleString() %> <a href="#" class="button-prev">Prev</a> <a href="#" class="button-next">Next</a></p>
 			<a href="#" class="avatar-wrap"><img src="<%= identity_avatar %>" /></a>
 			<div class="byline">
 				<h2><%= identity_name %></h2>

--- a/themes/default/views/pages/drop/js/drops.php
+++ b/themes/default/views/pages/drop/js/drops.php
@@ -286,7 +286,9 @@ $(function() {
 			"click .settings-toolbar .button-big a": "showFullDrop",
 			"click ul.score-drop > li.like a": "likeDrop",
 			"click ul.score-drop > li.dislike a": "dislikeDrop",
-			"click li.share > a": "shareDrop"
+			"click li.share > a": "shareDrop",
+			"click a.button-prev": "showPrevDrop",
+			"click a.button-next": "showNextDrop"
 		},
 		
 		initialize: function() {
@@ -349,7 +351,27 @@ $(function() {
 		showFullDrop: function() {
 			appRouter.navigate("/drop/" + this.model.get("id"), {trigger: true});
 			return false;
-		}	
+		},
+
+		showPrevDrop: function() {
+			var index = dropsList.indexOf(this.model)
+			if (index === dropsList.length - 1) {
+				return false;
+			}
+			var m = dropsList.at(index + 1);
+			appRouter.navigate("/drop/" + m.get("id")  + "/zoom", {trigger: true});
+			return false;
+		},
+
+		showNextDrop: function() {
+			var index = dropsList.indexOf(this.model)
+			if (index === 0) {
+				return false;
+			}
+			var m = dropsList.at(index - 1);
+			appRouter.navigate("/drop/" + m.get("id")  + "/zoom", {trigger: true});
+			return false;
+		}
 	});
 	
 	// Bucket in modal view


### PR DESCRIPTION
Closes #166 ("Next" and "Previous" buttons in the drop dialog)

Basic functionality and functions are implemented with some temporary anchors to demonstrate. Waiting on design @brandonrosage to decide where the buttons should go and how they should look.

Previous/Next functionality is based on backbone collection ordering defined by the drops list comparator.

<img src="https://lh4.googleusercontent.com/-XjG46KpMxY0/T-hJ5M2rMxI/AAAAAAAAACM/-QfFy0L_U8s/s720/1340623327920.png" />
