### PR TITLE
General invites

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -268,7 +268,7 @@ Route::set('river_maintenance', 'maintenance')
  */
 Route::set('account_pages', '<account>/<action>',
     array(
-    	'action' => '(rivers|buckets|create|settings|share|followers|following)'
+    	'action' => '(rivers|buckets|create|settings|share|followers|following|invite)'
     ))
 	->defaults(array(
 		'controller' => 'user',

--- a/application/classes/controller/settings/main.php
+++ b/application/classes/controller/settings/main.php
@@ -56,6 +56,7 @@ class Controller_Settings_Main extends Controller_Swiftriver {
 			'site_locale' => '',
 			'public_registration_enabled' => '',
 			'anonymous_access_enabled' => '',
+			'general_invites_enabled' => '',
 			'river_active_duration' => '',
 			'river_expiry_notice_period' => ''
 		);
@@ -80,6 +81,7 @@ class Controller_Settings_Main extends Controller_Swiftriver {
 					'site_locale' => $this->request->post('site_locale'),
 					'public_registration_enabled' => $this->request->post('public_registration_enabled') == 1,
 					'anonymous_access_enabled' => $this->request->post('anonymous_access_enabled') == 1,
+					'general_invites_enabled' => $this->request->post('general_invites_enabled') == 1,
 					'river_active_duration' => $this->request->post('river_active_duration'),
 					'river_expiry_notice_period' => $this->request->post('river_expiry_notice_period')
 				);

--- a/application/classes/controller/user.php
+++ b/application/classes/controller/user.php
@@ -753,7 +753,7 @@ class Controller_User extends Controller_Swiftriver {
 		$fetch_url = URL::site().$this->visited_account->account_path.'/user/followers/manage';
 	}
 
-	function action_invite()
+	public function action_invite()
 	{
 		if ( ! Model_Setting::get_setting('general_invites_enabled') OR ! $this->owner)
 			$this->request->redirect($this->dashboard_url);

--- a/application/classes/controller/user.php
+++ b/application/classes/controller/user.php
@@ -792,7 +792,7 @@ class Controller_User extends Controller_Swiftriver {
 				$valid_emails[] = $email;
 				$count++;
 
-				if ($count == $this->user->invites)
+				if ($count >= $this->user->invites)
 					break;
 			}
 

--- a/application/classes/controller/user.php
+++ b/application/classes/controller/user.php
@@ -774,6 +774,9 @@ class Controller_User extends Controller_Swiftriver {
 			$emails = explode(', ', $this->request->post('emails'));
 			foreach ($emails as $k => $email)
 			{
+				if ($count == $this->user->invites)
+					break;
+				
 				$email = trim($email);
 				if ( ! Valid::email($email, TRUE))
 				{
@@ -791,9 +794,6 @@ class Controller_User extends Controller_Swiftriver {
 
 				$valid_emails[] = $email;
 				$count++;
-
-				if ($count >= $this->user->invites)
-					break;
 			}
 
 			$this->user->invites -= $count;

--- a/application/classes/model/user.php
+++ b/application/classes/model/user.php
@@ -440,7 +440,7 @@ class Model_User extends Model_Auth_User {
 		$admin = FALSE;
 		if (Auth::instance()->logged_in())
 		{
-			$admin = Auth::instance()->get_user()->is_admin();
+			$admin = (Auth::instance()->get_user()->is_admin() || Model_Setting::get_setting('general_invites_enabled'));
 		}
 		
 		if ( ! (bool) Model_Setting::get_setting('public_registration_enabled') AND ! $admin)

--- a/install/sql/swiftriver.sql
+++ b/install/sql/swiftriver.sql
@@ -394,6 +394,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `password` varchar(255) NOT NULL,
   `api_key` varchar(255) NOT NULL,
   `logins` int(10) unsigned NOT NULL DEFAULT '0',
+  `invites` smallint(6) NOT NULL DEFAULT '10',
   `last_login` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`),
@@ -837,7 +838,8 @@ INSERT INTO `settings` (`id`, `key`, `value`) VALUES
 (4, 'public_registration_enabled', '0'),
 (5, 'anonymous_access_enabled', '0'),
 (6, 'river_active_duration', '14'),
-(7, 'river_expiry_notice_period', '3');
+(7, 'river_expiry_notice_period', '3'),
+(8, 'general_invites_enabled', '0');
 
 -- -----------------------------------------------------
 -- Data for table `users`

--- a/install/sql/updates/2012_07_16_00_settings.sql
+++ b/install/sql/updates/2012_07_16_00_settings.sql
@@ -1,0 +1,1 @@
+INSERT INTO `settings` (`key`, `value`) VALUES ('general_invites_enabled', '0');

--- a/install/sql/updates/2012_07_16_01_users.sql
+++ b/install/sql/updates/2012_07_16_01_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users` ADD COLUMN `invites` smallint(6) NOT NULL DEFAULT '10' AFTER `logins`;
+

--- a/themes/default/views/pages/settings/main.php
+++ b/themes/default/views/pages/settings/main.php
@@ -86,6 +86,12 @@
 					<?php echo __('Allow anonymous access'); ?>
 				</label>
 			</div>
+			<div class="parameter">
+				<label for="general_invites_enabled">
+					<?php echo Form::checkbox('general_invites_enabled', 1,  (bool)$settings['general_invites_enabled']); ?>
+					<?php echo __('Allow general invites'); ?>
+				</label>
+			</div>
 		</section>
 	</article>
 	<article class="container base">

--- a/themes/default/views/pages/user/invite.php
+++ b/themes/default/views/pages/user/invite.php
@@ -1,0 +1,86 @@
+<div class="col_12">
+	<?php if (isset($errors)): ?>
+		<div class="alert-message red">
+		<p><strong>Uh oh.</strong></p>
+		<ul>
+			<?php if (is_array($errors)): ?>
+				<?php foreach ($errors as $error): ?>
+					<li><?php echo $error; ?></li>
+				<?php endforeach; ?>
+			<?php else: ?>
+				<li><?php echo $errors; ?></li>
+			<?php endif; ?>
+		</ul>
+		</div>
+	<?php endif; ?>
+	<?php if (isset($messages)): ?>
+		<div class="alert-message blue">
+		<p><strong>Success.</strong></p>
+		<ul>
+			<?php if (is_array($messages)): ?>
+				<?php foreach ($messages as $message): ?>
+					<li><?php echo $message; ?></li>
+				<?php endforeach; ?>
+			<?php else: ?>
+				<li><?php echo $messages; ?></li>
+			<?php endif; ?>
+		</ul>
+		</div>
+	<?php endif; ?>
+
+	<?php echo Form::open(NULL, array('id' => 'invites-form')); ?>
+	<input type="hidden" name="emails" value="" />
+	<article class="container base">
+		<header class="cf">
+			<div class="property-title">
+				<h1>Email</h1>
+				<div class="popover add-parameter"><?php if ($user->invites > 0): ?>
+					<p class="button-white add has-icon"><a href="#"><span class="icon"></span>Add more (<?php echo $user->invites-1; ?>)</a></p><?php endif; ?>
+				</div>
+			</div>
+		</header>
+		<section class="property-parameters">
+			<div class="parameter">
+				<label for="email">
+					<p class="field">Email Address</p>
+					<input type="text" class="form-email" placeholder="Enter recipient's email address">
+					<p class="remove-small actions"><span class="icon"></span><span class="nodisplay">Remove</span></p>
+				</label>
+			</div>
+		</section>
+	</article>
+	
+	<div class="save-toolbar">
+		<p class="button-blue"><a href="#" onClick="onSendInvite()"><?php echo __("Send"); ?></a></p>
+	</div>
+	<?php echo Form::close(); ?>
+
+<script type="text/javascript">
+	//var line_content = $('div.parameter').last().clone().wrap('<div>').parent().html();
+	var line_content = $('.property-parameters').first().html();
+	var invites = <?php echo $user->invites; ?>;
+	$('.add a').click(function() {
+		if ($('div.parameter').length < invites) {
+			$('section.property-parameters').append(line_content);
+			$('.add a').html('<span class="icon"></span>Add more ('+(invites-$('div.parameter').length)+')');
+			$('p.remove-small').click(function() {
+				$(this).parent().parent().remove();
+				$('.add a').html('<span class="icon"></span>Add more ('+(invites-$('div.parameter').length)+')');
+			});
+		}
+		return false;
+	});
+	$('p.remove-small').click(function() {
+		$(this).parent().parent().remove();
+		$('.add a').html('<span class="icon"></span>Add more ('+(invites-$('div.parameter').length)+')');
+	});
+	function onSendInvite() {
+		$('.save-toolbar a').removeClass('visible');
+		var emails = [];
+		$('input.form-email').each(function(){emails.push($(this).val());});
+		$('input[name=emails]').val(emails.join(', '));
+		submitForm('.save-toolbar a');
+		//$('.save-toolbar a').click('onSendInvite');
+		return false;
+	}
+</script>

--- a/themes/default/views/pages/user/invite.php
+++ b/themes/default/views/pages/user/invite.php
@@ -29,13 +29,13 @@
 	<?php endif; ?>
 
 	<?php echo Form::open(NULL, array('id' => 'invites-form')); ?>
-	<input type="hidden" name="emails" value="" />
+	<input type="hidden" name="emails" value="" /><?php if ($user->invites > 0): ?>
 	<article class="container base">
 		<header class="cf">
 			<div class="property-title">
 				<h1>Email</h1>
-				<div class="popover add-parameter"><?php if ($user->invites > 0): ?>
-					<p class="button-white add has-icon"><a href="#"><span class="icon"></span>Add more (<?php echo $user->invites-1; ?>)</a></p><?php endif; ?>
+				<div class="popover add-parameter">
+					<p class="button-white add has-icon"><a href="#"><span class="icon"></span>Add more (<?php echo $user->invites-1; ?>)</a></p>
 				</div>
 			</div>
 		</header>
@@ -52,7 +52,13 @@
 	
 	<div class="save-toolbar">
 		<p class="button-blue"><a href="#" onClick="onSendInvite()"><?php echo __("Send"); ?></a></p>
-	</div>
+	</div><?php else: ?>
+	<div class="alert-message red">
+		<p><strong>Uh oh.</strong></p>
+		<ul>
+			<li>You have no invites to send!</li>
+		</ul>
+	</div><?php endif; ?>
 	<?php echo Form::close(); ?>
 
 <script type="text/javascript">

--- a/themes/default/views/pages/user/layout.php
+++ b/themes/default/views/pages/user/layout.php
@@ -32,8 +32,12 @@
 			<a href="<?php echo URL::site().$account->account_path.'/settings'; ?>">
 				<?php echo __("Account Settings"); ?>
 			</a>
-		</li>
-
+		</li><?php if (Model_Setting::get_setting('general_invites_enabled')): ?>
+		<li <?php if ($active == 'invites') echo 'class="active"'; ?>>
+			<a href="<?php echo URL::site().$account->account_path.'/invite'; ?>">
+				<?php echo __("Invites"); ?>
+			</a>
+		</li><?php endif; ?>
 	</ul>
 </nav>
 <?php endif; ?>


### PR DESCRIPTION
Closes #181

Implements ability for regular users to invite if enabled by administrator. Users have by default 10 invites (changeable). Total number of invites are sent to client JS to make the interface a bit more user-friendly (able to send more than one invite at a time).

The entire tab will disappear if the option is disabled.

<a href="https://picasaweb.google.com/lh/photo/RyXbpjfb0JNMZc7MASs2YcjBVG_0f5B7oOHmZugTIg0?feat=embedwebsite"><img src="https://lh3.googleusercontent.com/-mx2NVfqJNJQ/UAQMN4lzWYI/AAAAAAAAAFw/xU5HkLPA95Y/s800/1342442549121.png" /></a>
