### PR TITLE
Fix avatar alignment in activity stream

### DIFF
--- a/themes/default/media/css/less/styles.less
+++ b/themes/default/media/css/less/styles.less
@@ -1591,7 +1591,7 @@ article.container div.parameter input[type="password"] {
 }
 
 article.container div.parameter textarea,
-article.container div.parameter img {
+article.container div.image-field img {
    margin-left: 30px;
 }
 

--- a/themes/default/media/css/styles.css
+++ b/themes/default/media/css/styles.css
@@ -1328,7 +1328,7 @@ article.container div.parameter input[type="password"] {
   margin-left: 30px;
 }
 article.container div.parameter textarea,
-article.container div.parameter img {
+article.container div.image-field img {
   margin-left: 30px;
 }
 article.container div.parameter div.actions {

--- a/themes/default/views/pages/drop/drops.php
+++ b/themes/default/views/pages/drop/drops.php
@@ -514,7 +514,7 @@
 		</article>
 		<article class="container base">
 			<section class="property-parameters">
-				<div class="parameter">
+				<div class="parameter image-field">
 				    <label>
 					    <p class="field"><?php echo __("Security Image:"); ?></p>
 						<?php echo Captcha::instance()->render(); ?>


### PR DESCRIPTION
- CSS changes introduced by 007b88b1cb5700dadbc1f9e23834bbc83205f8c0
  caused the avatars in the activity stream to be offset by 30px from the
  left margin

This fixes the appearance of the activity stream from:
![Glitchy activity stream](https://dl.dropbox.com/u/2635815/activity-stream-glitch.png)

to
![Fixed Activity Stream](https://dl.dropbox.com/u/2635815/fixed-activity-stream-css.png)
