### PR TITLE
Quotas for channel options - Closes #216

### DIFF
--- a/application/classes/controller/settings/quotas.php
+++ b/application/classes/controller/settings/quotas.php
@@ -1,0 +1,63 @@
+<?php defined('SYSPATH') OR die('No direct script access');
+
+/**
+ * Channel Quotas settings controller
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to GPLv3 license 
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/gpl.html
+ * @author     Ushahidi Dev Team
+ * @package	   SwiftRiver - http://github.com/ushahidi/Swiftriver_v2
+ * @category   Controllers
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU General Public License v3 (GPLv3) 
+ */
+
+class Controller_Settings_Quotas extends Controller_Settings_Main {
+	
+	/**
+	 * Landing page for this controller
+	 */
+	public function action_index()
+	{
+		$this->template->header->title = __("Channel Quotas");
+		$this->settings_content = View::factory('pages/settings/quotas')
+		    ->bind('post_url', $post_url)
+		    ->bind('quotas', $quotas);
+
+		$this->active = 'quotas';
+		$post_url = URL::site('settings/quotas/manage');
+		$quotas = json_encode(Model_Channel_Quota::get_quotas_array());
+	}
+
+	/**
+	 * REST endpoint for (de)activation of channel quotas
+	 */
+	public function action_manage()
+	{
+		$this->template = '';
+		$this->auto_render = FALSE;
+
+		switch ($this->request->method())
+		{
+			case "POST":
+				$payload = json_decode($this->request->body(), TRUE);
+				$quota_orm = Model_Channel_Quota::add_quota($payload);
+
+				echo json_encode($quota_orm->as_array());
+			break;
+
+			case "PUT":
+				$payload = json_decode($this->request->body(), TRUE);
+				$quota_id = $payload['id'];
+				$quota_orm = ORM::factory('channel_quota', $quota_id);
+				if ($quota_orm->loaded())
+				{
+					$quota_orm->quota = $payload['quota'];
+					$quota_orm->save();
+				}
+			break;
+		}
+	}
+}

--- a/application/classes/model/channel/filter/option.php
+++ b/application/classes/model/channel/filter/option.php
@@ -14,7 +14,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU General Public License v3 (GPLv3) 
  */
 class Model_Channel_Filter_Option extends ORM {
-	
+
 	/**
 	 * A channel_filter_option belongs to a channel_filter
 	 * @var array Relationhips
@@ -28,6 +28,18 @@ class Model_Channel_Filter_Option extends ORM {
 	 */
 	public function save(Validation $validation = NULL)
 	{
+		$channel_filter = ORM::factory('channel_filter', $this->channel_filter_id);
+
+		$option_data = array(
+			'user_id' => $channel_filter->river->account->user_id,
+			'channel' => $channel_filter->channel,
+			'channel_option' => $this->key
+		);
+
+		// Update the quota usage
+		Model_User_Quota::update_quota_usage($option_data);
+
+		// Check the quota for this channel option
 		$ret = parent::save();
 		
 		// Run post_save events
@@ -35,7 +47,7 @@ class Model_Channel_Filter_Option extends ORM {
 		
 		return $ret;
 	}
-	
+
 	/**
 	 * Overrides the default behaviour to perform
 	 * extra tasks before removing the channel filter
@@ -45,12 +57,19 @@ class Model_Channel_Filter_Option extends ORM {
 	{
 		Swiftriver_Event::run('swiftriver.channel.option.pre_delete', $this);
 
-		// Default
+		$option_data = array(
+			'user_id' => $this->channel_filter->river->account->user_id,
+			'channel' => $this->channel_filter->channel,
+			'channel_option' => $this->key
+		);
+
+		// Update quota usage
+		Model_User_Quota::update_quota_usage($option_data, FALSE);
+
+		// Delete the filter option
 		parent::delete();
 	}
-	
-	
-	
+
 	/**
 	 * Parses the "value" column of the channel filter option and returns it 
 	 * as an array
@@ -65,4 +84,3 @@ class Model_Channel_Filter_Option extends ORM {
 		return array($this->key => $options);
 	}
 }
-?>

--- a/application/classes/model/channel/quota.php
+++ b/application/classes/model/channel/quota.php
@@ -1,0 +1,143 @@
+<?php defined('SYSPATH') or die('No direct script access');
+
+/**
+ * Model for the channel_quotas table
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to GPLv3 license 
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/gpl.html
+ * @author     Ushahidi Team <team@ushahidi.com> 
+ * @package    SwiftRiver - http://github.com/ushahidi/Swiftriver_v2
+ * @category   Models
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU General Public License v3 (GPLv3) 
+ */
+
+class Model_Channel_Quota extends ORM {
+	
+
+	/**
+	 * Validation rules to be run before save/update operations
+	 * @return array
+	 */
+	public function rules()
+	{
+		return array(
+			'quota' => array(
+				array('not_empty'),
+				array('digit')
+			)
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	public static function get_quotas_array()
+	{
+		$quotas = array();
+
+		// Load the list of channels
+		$channels = Swiftriver_Plugins::channels();
+
+		// Ge the channel quota entries from the DB
+		$db_channel_quotas = self::get_db_channel_quotas();
+
+		// Populate the return value
+		foreach ($channels as $channel)
+		{
+			$entries = array();
+
+			$channel_options = $channel['options'];
+			foreach ($channel_options as $option => $options)
+			{
+				if ($options['type'] !== 'text')
+					continue;
+
+				// Initialize the quota id and channel quota
+				list($quota_id, $quota) = array(NULL, 0);
+
+				// Canonical channel name
+				$channel_name = $channel['channel'];
+
+				// Get the quota entries stored in the DB
+				if (array_key_exists($channel_name, $db_channel_quotas))
+				{
+					if (array_key_exists($option, $db_channel_quotas[$channel_name]))
+					{
+						$quota_id = $db_channel_quotas[$channel_name][$option]['id'];
+						$quota = $db_channel_quotas[$channel_name][$option]['quota'];
+					}
+				}
+
+				$entries[] = array(
+					'id' => $quota_id,
+					'channel' => $channel['channel'],
+					'label' => $options['label'],
+					'channel_option' => $option,
+					'quota' => $quota
+				);
+			}
+
+			$quotas[] = array('channel_name' => $channel['name'], 'quota_options' => $entries);
+		}
+
+		return $quotas;
+	}
+
+	/**
+	 * Gets the quota for a specific channel option
+	 *
+	 * @param  string  $channel Name of the channel
+	 * @param  string  $option  Channel option
+	 */
+	public static function get_channel_quota($channel, $option)
+	{
+		$quota_orm = ORM::factory('channel_quota')
+		    ->where('channel', '=', $channel)
+		    ->where('channel_option', '=', $option)
+		    ->find();
+
+		return $quota_orm->loaded() ? $quota_orm->quota : 0;
+	}
+
+	/**
+	 * Given an array of the quota properties, adds a chanel quota entry
+	 *
+	 * @param  array $quota_dat key-value array of the quota properties
+	 * @return Model_Channel_Quota
+	 */
+	public static function add_quota($quota_data)
+	{
+		$quota_orm = new Model_Channel_Quota();
+		$quota_orm->channel = $quota_data['channel'];
+		$quota_orm->channel_option = $quota_data['channel_option'];
+		$quota_orm->quota = $quota_data['quota'];
+		return $quota_orm->save();
+	}
+
+	/**
+	 * Gets the channel quotas from the DB with the otions grouped per
+	 * channel
+	 *
+	 * @return array
+	 */
+	private static function get_db_channel_quotas()
+	{
+		$db_quotas = array();
+		foreach (ORM::factory('channel_quota')->find_all() as $quota)
+		{
+			if ( ! array_key_exists($quota->channel, $db_quotas))
+			{
+				$db_quotas[$quota->channel] = array();
+			}
+
+			$db_quotas[$quota->channel][$quota->channel_option] = array(
+				'id' => $quota->id,
+				'quota' => $quota->quota
+			);
+		}
+		return $db_quotas;
+	}
+}

--- a/application/classes/model/user/quota.php
+++ b/application/classes/model/user/quota.php
@@ -1,0 +1,72 @@
+<?php defined('SYSPATH') or die('No direct script access');
+
+/**
+ * Model for the user_quotas table
+ *
+ * PHP version 5
+ * LICENSE: This source file is subject to GPLv3 license 
+ * that is available through the world-wide-web at the following URI:
+ * http://www.gnu.org/copyleft/gpl.html
+ * @author     Ushahidi Team <team@ushahidi.com> 
+ * @package    SwiftRiver - http://github.com/ushahidi/Swiftriver_v2
+ * @category   Models
+ * @copyright  Ushahidi - http://www.ushahidi.com
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU General Public License v3 (GPLv3) 
+ */
+
+class Model_User_Quota extends ORM {
+
+	/**
+	 * Updates a users quota usage
+	 * @param  array $option
+	 * @param  bool $add When TRUE, increments the no. of options used
+	 */
+	public static function update_quota_usage($option, $add = TRUE)
+	{
+		// Get the quota entry		
+		$quota_orm = ORM::factory('user_quota')
+		   ->where('user_id', '=', $option['user_id'])
+		   ->where('channel', '=', $option['channel'])
+		   ->where('channel_option', '=', $option['channel_option'])
+		   ->find();
+
+		// Create a new quota entry when add = TRUE
+		if ( ! $quota_orm->loaded() AND $add)
+		{
+			$quota_orm = new Model_User_Quota();
+			$quota_orm->user_id = $option['user_id'];
+			$quota_orm->channel = $option['channel'];
+			$quota_orm->channel_option = $option['channel_option'];
+			$quota_orm->quota_usage = 1;
+			$quota_orm->save();
+		}
+
+		if ($quota_orm->loaded())
+		{
+			if ($add)
+			{
+				// Get the limits
+				$option_quota = Model_Channel_Quota::get_channel_quota(
+					$option['channel'], $option['channel_option']);
+
+				if ($option_quota === 0 OR ($quota_orm->quota_usage < $option_quota))
+				{
+					$quota_orm->quota_usage += 1;
+					$quota_orm->save();
+				}
+				else
+				{
+					// Quota exhausted, throw exception
+					throw new HTTP_Exception_400(__("You have exhausted your quota for :channel",
+						array(":channel" => $option['channel'])));
+				}
+			}
+			else
+			{
+				$quota_orm->quota_usage -= 1;
+				$quota_orm->save();
+			}
+		}
+	}
+
+}

--- a/application/classes/swiftriver/plugins.php
+++ b/application/classes/swiftriver/plugins.php
@@ -197,6 +197,9 @@ class Swiftriver_Plugins {
 		                     ->find_all();
 		foreach ($active_plugins as $active_plugin)
 		{
+			if ( ! isset($config_plugins[$active_plugin->plugin_path]))
+				continue;
+
 			$plugin_config = $config_plugins[$active_plugin->plugin_path];
 			if (isset($plugin_config['channel']) AND $plugin_config['channel'] == TRUE )
 			{
@@ -288,21 +291,17 @@ class Swiftriver_Plugins {
 		{
 			$all_plugin_configs = Kohana::$config->load('plugin');
 			$plugin_configs = $all_plugin_configs->get($plugin);
-			if ( is_array($plugin_configs) 
+			if
+			(
+				is_array($plugin_configs) 
 				AND isset($plugin_configs['settings']) 
-				AND $plugin_configs['settings'] == TRUE )
+				AND $plugin_configs['settings'] == TRUE
+			)
 			{
 				return TRUE;
 			}
-			else
-			{
-				return FALSE;
-			}
 		}
-		else
-		{
-			return FALSE;
-		}
+		return FALSE;
 	}
 
 
@@ -317,21 +316,18 @@ class Swiftriver_Plugins {
 		{
 			$all_plugin_configs = Kohana::$config->load('plugin');
 			$plugin_configs = $all_plugin_configs->get($plugin);
-			if ( is_array($plugin_configs) 
+			if
+			(
+				is_array($plugin_configs)
 				AND isset($plugin_configs['service']) 
-				AND $plugin_configs['service'] == TRUE )
+				AND $plugin_configs['service'] == TRUE
+			)
 			{
 				return TRUE;
 			}
-			else
-			{
-				return FALSE;
-			}
 		}
-		else
-		{
-			return FALSE;
-		}
+
+		return FALSE;
 	}
 
 	/**

--- a/install/sql/swiftriver.sql
+++ b/install/sql/swiftriver.sql
@@ -867,3 +867,29 @@ INSERT INTO `accounts` (`user_id`, `account_path`) VALUES
 (2, 'public');
 
 COMMIT;
+
+-- -----------------------------------------------------
+-- Table `channel_quotas`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `channel_quotas` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `channel` varchar(100) NOT NULL DEFAULT '' COMMENT 'Channel on which to apply the quota',
+  `channel_option` varchar(100) NOT NULL,
+  `quota` int(11) NOT NULL DEFAULT 0 COMMENT 'No. of allowable options for the specified channel',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `un_channel_option` (`channel`,`channel_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- -----------------------------------------------------
+-- Table `user_quotas`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `user_quotas` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) NOT NULL,
+  `channel` varchar(100) NOT NULL DEFAULT '',
+  `channel_option` varchar(100) NOT NULL DEFAULT '',
+  `quota_usage` int(11) NOT NULL DEFAULT 0 COMMENT 'Current no. of options that the user has used up',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `un_channel_option` (`channel`,`channel_option`),
+  KEY `idx_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/install/sql/updates/2012_09_04_00_channel_quotas.sql
+++ b/install/sql/updates/2012_09_04_00_channel_quotas.sql
@@ -1,0 +1,25 @@
+-- -----------------------------------------------------
+-- Table `channel_quotas`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `channel_quotas` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `channel` varchar(100) NOT NULL DEFAULT '' COMMENT 'Channel on which to apply the quota',
+  `channel_option` varchar(100) NOT NULL,
+  `quota` int(11) NOT NULL DEFAULT 0 COMMENT 'No. of allowable options for the specified channel',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `un_channel_option` (`channel`,`channel_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- -----------------------------------------------------
+-- Table `user_quotas`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `user_quotas` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) NOT NULL,
+  `channel` varchar(100) NOT NULL DEFAULT '',
+  `channel_option` varchar(100) NOT NULL DEFAULT '',
+  `quota_usage` int(11) NOT NULL DEFAULT 0 COMMENT 'Current no. of options that the user has used up',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `un_channel_option` (`channel`,`channel_option`),
+  KEY `idx_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/themes/default/views/pages/settings/layout.php
+++ b/themes/default/views/pages/settings/layout.php
@@ -20,6 +20,9 @@
 		<li <?php if ($active == 'plugins') echo 'class="active"'; ?>>
 			<a href="<?php echo URL::site().'settings/plugins';?>"><?php echo __('Plugins'); ?></a>
 		</li>
+		<li <?php if ($active == 'quotas') echo 'class="active"'; ?>>
+			<a href="<?php echo URL::site('settings/quotas'); ?>"><?php echo __('Channel Quotas'); ?></a>
+		</li>
 		<?php
 			// Swiftriver Plugin Hook -- add settings nav item
 			Swiftriver_Event::run('swiftriver.settings.nav', $active);

--- a/themes/default/views/pages/settings/quotas.php
+++ b/themes/default/views/pages/settings/quotas.php
@@ -1,0 +1,187 @@
+<?php echo Form::open(); ?> 
+	<input type="hidden" name="action" value="">
+	<input type="hidden" name="id" value="">
+	<div class="settings-toolbar"></div>
+<?php echo Form::close(); ?>
+
+<script type="text/template" id="quota-template">
+	<header class="cf">
+		<div class="property-title">
+			<h1><%= channel_name %></h1>
+		</div>
+	</header>
+	<section class="property-parameters">
+	</section>
+</script>
+
+<script type="text/template" id="quota-item-template">
+	<label for="<%= channel_option %>">
+		<p class="field"><?php echo __("No. of "); ?><%= label %>s</p>
+		<input type="text" name="<%= channel_option %>" value="<%= quota %>">
+		<p class="actions" style="display:none;">
+			<span class="button-blue"><a class="cancel" href="#"><?php echo __("Cancel"); ?></a></span>
+		</p>
+		<p class="actions" style="display:none;">
+			<span class="button-blue"><a class="save" href="#"><?php echo __("Save"); ?></a></span>
+		</p>
+	</label>
+</script>
+
+<script type="text/javascript">
+$(function(){
+
+	var postURL = "<?php echo $post_url; ?>";
+
+	var Channel = Backbone.Model.extend();
+	var ChannelList = Backbone.Collection.extend({
+		model: Channel
+	});
+
+	var ChannelQuota = Backbone.Model.extend({
+		url: postURL
+	});
+
+	var channelList = new ChannelList();
+
+	// View for a single channel and the quotas for each of its options
+	var ChannelQuotaView = Backbone.View.extend({
+
+		tagName: "article",
+
+		className: "container base",
+
+		template: _.template($("#quota-template").html()),
+
+		addChannelQuotaItem: function(quotaItem) {
+			var view = new ChannelQuotaItemView({model: quotaItem});
+			this.$("section.property-parameters").prepend(view.render().el);
+		},
+
+		render: function() {
+			this.$el.html(this.template({channel_name: this.model.get("channel_name")}));
+			_.each(this.model.get("quota_options"), function(option){
+				var quotaItem = new ChannelQuota(option);
+				this.addChannelQuotaItem(quotaItem);
+			}, this);
+			return this;
+		}
+	});
+
+	// View a single channel option quota
+	var ChannelQuotaItemView = Backbone.View.extend({
+
+		tagName: "div",
+
+		className: "parameter",
+
+		template: _.template($("#quota-item-template").html()),
+
+		events: {
+			// When the save button is clicked
+			"click a.save": "save",
+
+			// When the cancel button is clicked
+			"click a.cancel": "cancel",
+
+			// When the textbox contents change
+			"keyup input": "toggleEditButtons",
+
+			"focusout input": "toggleEditButtons",
+		},
+
+		// When the save button is clicked
+		save: function(e) {
+			this.hideButtons();
+			// Clear any error messages
+			this.$(".error-message").remove();
+			
+			var value = this.$("input").val();
+
+			this.$("input").attr("readonly", true);
+			var postData = {quota: value};
+
+			if (this.model.get("id") === null) {
+				postData.channel = this.model.get("channel");
+				postData.channel_option = this.model.get("channel_option");
+			}
+
+			var loading_msg = window.loading_image.clone();
+			var context = this;
+			this.$("input").after(loading_msg);
+
+			// Show loading icon
+			this.model.save(postData, {
+				wait: true,
+
+				// Successful saving
+				success: function(model, response) {
+					var successMsg = $('<span class="success-message">Saved</span>');
+					loading_msg.replaceWith(successMsg);
+					successMsg.fadeOut(1500, function(){ context.$("input").removeAttr("readonly"); });					
+				},
+				// When an error is returned
+				error: function(model, response) {
+					var message = "Oops, unable to save. Try again.";
+					if (response.status == 400) {
+						message = JSON.parse(response.responseText)["error"];
+					} 
+					var error_msg = $('<span class="error-message">' + message + '</span>');
+					loading_msg.replaceWith(error_msg).remove();
+					context.$("input").removeAttr("readonly");
+				}
+			});
+			return false;
+		},
+
+		// Handles click events for the cancel button
+		cancel: function(e) {
+			// Restore original value
+			this.$("input").val(this.model.get("quota"));
+
+			// Hide the action buttons
+			this.hideButtons();
+			return false;
+		},
+
+		hideButtons: function() {
+			this.$("p.actions").fadeOut("slow");
+		},
+
+		toggleEditButtons: function(e) {
+			var inputVal = $(e.currentTarget).val();
+			if (this.model.get("quota") !== $.trim(inputVal)) {
+				this.$("p.actions").fadeIn("slow");
+			} else {
+				this.$("p.actions").fadeOut("slow");
+			}
+			return false;
+		},
+
+		render: function() {
+			this.$el.html(this.template(this.model.toJSON()));
+			return this;
+		}
+	});
+
+	// Initialize the quotas view
+	var QuotasView = Backbone.View.extend({
+
+		initialize: function() {
+			channelList.on("add", this.addChannel, this);
+			channelList.on("reset", this.addChannels, this);
+		},
+
+		addChannels: function() {
+			channelList.each(this.addChannel, this);
+		},
+
+		addChannel: function(channel) {
+			var view = new ChannelQuotaView({model: channel});
+			$("div.settings-toolbar").after(view.render().el);
+		}
+	});
+
+	var quotasView = new QuotasView();
+	channelList.reset(<?php echo $quotas; ?>);
+});
+</script>


### PR DESCRIPTION
- The channel quotas are only configurable by the administrator so the
  function is accessed via the "Site Settings" menu item.
  ![Channel Quotas](https://dl.dropbox.com/u/2635815/channel-quotas.png)
- This feature tracks how many channel options each user has used up.
  We therefore keep track of each user's usage each time a channel option
  is added/removed. When a user maxes out the limit, the API returns a
  status 400
- The quotas are only for channel options that are specified via a
  textbox and the premise is that users specify one option per textfield.
- On the UI, each quota item is saved individually:
  ![Save Quota Item](https://dl.dropbox.com/u/2635815/save-quota-item.png)
