### PR TITLE
Remove processing_status from predicate list in drop fetch query

### DIFF
--- a/application/classes/controller/bucket.php
+++ b/application/classes/controller/bucket.php
@@ -385,32 +385,41 @@ class Controller_Bucket extends Controller_Drop_Base {
 					throw new HTTP_Exception_404();
 				}
 				
-				if (!$bucket_array['subscribed']) {
+				if ( ! $bucket_array['subscribed'])
+				{
 					// Unsubscribing
 					
 					// Unfollow
-					if ($this->user->has('bucket_subscriptions', $bucket_orm)) {
+					if ($this->user->has('bucket_subscriptions', $bucket_orm))
+					{
 						$this->user->remove('bucket_subscriptions', $bucket_orm);
 					}
 					
 					// Stop collaborating
 					$collaborator_orm = $bucket_orm->bucket_collaborators
-													->where('user_id', '=', $this->user->id)
-													->where('collaborator_active', '=', 1)
-													->find();
+					                        ->where('user_id', '=', $this->user->id)
+					                        ->where('collaborator_active', '=', 1)
+					                        ->find();
 					if ($collaborator_orm->loaded())
 					{
 						$collaborator_orm->delete();
 						$bucket_array['is_owner'] = FALSE;
 						$bucket_array['collaborator'] = FALSE;
 					}
-				} else {
+
+					Cache::instance()->delete('user_buckets_'.$this->user->id);
+				}
+				else
+				{
 					// Subscribing
-					
-					if (!$this->user->has('bucket_subscriptions', $bucket_orm)) {
+					if ( ! $this->user->has('bucket_subscriptions', $bucket_orm))
+					{
 						$this->user->add('bucket_subscriptions', $bucket_orm);
 					}
+
+					Cache::instance()->delete('user_buckets_'.$this->user->id);
 				}
+
 				// Return updated bucket
 				echo json_encode($bucket_array);
 			break;
@@ -435,7 +444,8 @@ class Controller_Bucket extends Controller_Drop_Base {
 					$this->response->status(400);
 					$this->response->headers('Content-Type', 'application/json');
 					$errors = array();
-					foreach ($e->errors('validation') as $message) {
+					foreach ($e->errors('validation') as $message)
+					{
 						$errors[] = $message;
 					}
 					echo json_encode(array('errors' => $errors));
@@ -444,12 +454,13 @@ class Controller_Bucket extends Controller_Drop_Base {
 				{
 					$this->response->status(400);
 					$this->response->headers('Content-Type', 'application/json');
-					$errors = array(__("A bucket with the name ':name' already exists", 
-					                                array(':name' => $bucket_array['bucket_name']
-					)));
+					$errors = array(__("A bucket with the name ':name' already exists",
+						array(':name' => $bucket_array['bucket_name'])
+					));
 					echo json_encode(array('errors' => $errors));
 				}
 			break;
+
 			case "DELETE":
 				$bucket_id = intval($this->request->param('id', 0));
 				$bucket_orm = ORM::factory('bucket', $bucket_id);
@@ -463,6 +474,7 @@ class Controller_Bucket extends Controller_Drop_Base {
 					}
 					
 					$bucket_orm->delete();
+					Cache::instance()->delete('user_buckets_'.$this->user->id);
 				}
 				else
 				{

--- a/application/classes/controller/drop.php
+++ b/application/classes/controller/drop.php
@@ -38,8 +38,7 @@ class Controller_Drop extends Controller_Swiftriver {
 				// Get the POST data
 				$drops = json_decode($this->request->body(), TRUE);
 				Kohana::$log->add(Log::DEBUG, ":count Drops received", array(':count' => count($drops)));
-				list(, $new_drops) = Model_Droplet::create_from_array($drops);
-				echo json_encode($new_drops);
+				Model_Droplet::create_from_array($drops);
 			break;
 		}
 	 }

--- a/application/classes/controller/river.php
+++ b/application/classes/controller/river.php
@@ -400,7 +400,6 @@ class Controller_River extends Controller_Drop_Base {
 	
 	/**
 	 * River management
-	 * 
 	 */
 	public function action_manage()
 	{
@@ -422,36 +421,43 @@ class Controller_River extends Controller_Drop_Base {
 				{
 					throw new HTTP_Exception_404();
 				}
-				
-				if (!$river_array['subscribed']) {
-					// Unsubscribing
-					
-					// Unfollow
-					if ($this->user->has('river_subscriptions', $river_orm)) {
+
+				if ( ! $river_array['subscribed'])
+				{
+					// Unsubscribe					
+					if ($this->user->has('river_subscriptions', $river_orm))
+					{
 						$this->user->remove('river_subscriptions', $river_orm);
 					}
 					
 					// Stop collaborating
 					$collaborator_orm = $river_orm->river_collaborators
-													->where('user_id', '=', $this->user->id)
-													->where('collaborator_active', '=', 1)
-													->find();
+					                        ->where('user_id', '=', $this->user->id)
+					                        ->where('collaborator_active', '=', 1)
+					                        ->find();
 					if ($collaborator_orm->loaded())
 					{
 						$collaborator_orm->delete();
 						$river_array['is_owner'] = FALSE;
 						$river_array['collaborator'] = FALSE;
 					}
-				} else {
-					// Subscribing
-					
-					if (!$this->user->has('river_subscriptions', $river_orm)) {
+
+					Cache::instance()->delete('user_rivers_'.$this->user->id);
+				}
+				else
+				{
+					// Subscribing				
+					if ( ! $this->user->has('river_subscriptions', $river_orm))
+					{
 						$this->user->add('river_subscriptions', $river_orm);
 					}
+
+					Cache::instance()->delete('user_rivers_'.$this->user->id);
 				}
 				// Return updated bucket
 				echo json_encode($river_array);
 			break;
+
 			case "DELETE":
 				$river_id = intval($this->request->param('id', 0));
 				$river_orm = ORM::factory('river', $river_id);
@@ -465,6 +471,7 @@ class Controller_River extends Controller_Drop_Base {
 					}
 					
 					$river_orm->delete();
+					Cache::instance()->delete('user_rivers_'.$this->user->id);
 				}
 				else
 				{

--- a/application/classes/controller/river/create.php
+++ b/application/classes/controller/river/create.php
@@ -83,6 +83,9 @@ class Controller_River_Create extends Controller_River {
 			{
 				$river = Model_River::create_new($post['river_name'], $post['river_public'], $this->user->account);
 
+				// Delete the rivers cache so that it's recreated on page reload
+				Cache::instance()->delete('user_rivers_'.$this->user->id);
+
 				// Redirect to the /create/open/<id> to open channels
 				$this->request->redirect(URL::site().$this->account_path.'/river/create/open/'.$river->id);
 			}

--- a/application/classes/model/bucket.php
+++ b/application/classes/model/bucket.php
@@ -216,7 +216,6 @@ class Model_Bucket extends ORM {
 				->join('links', 'LEFT')
 			    ->on('links.id', '=', 'droplets.original_url')
 				->where('buckets_droplets.bucket_id', '=', $bucket_id)
-				->where('droplets.processing_status', '=', Model_Droplet::PROCESSING_STATUS_COMPLETE)
 				->where('droplets.parent_id', '=', 0);
 				
 			if ($drop_id)
@@ -322,7 +321,6 @@ class Model_Bucket extends ORM {
 				->join('links', 'LEFT')
 			    ->on('links.id', '=', 'droplets.original_url')
 				->where('buckets_droplets.bucket_id', '=', $bucket_id)
-				->where('droplets.processing_status', '=', Model_Droplet::PROCESSING_STATUS_COMPLETE)
 				->where('droplets.parent_id', '=', 0)
 				->where('buckets_droplets.id', '>', $since_id)
 				->order_by('buckets_droplets.id', 'ASC');

--- a/application/classes/model/droplet.php
+++ b/application/classes/model/droplet.php
@@ -232,7 +232,9 @@ class Model_Droplet extends ORM {
 		Model_Media::get_media($droplets);
 		
 		// Populate the drop's metadata tables
-		self::add_metadata($droplets);		
+		self::add_metadata($droplets);
+		
+		return array($droplets, $new_droplets); 
 	}
 	
 	/**

--- a/application/classes/model/droplet.php
+++ b/application/classes/model/droplet.php
@@ -232,9 +232,7 @@ class Model_Droplet extends ORM {
 		Model_Media::get_media($droplets);
 		
 		// Populate the drop's metadata tables
-		self::add_metadata($droplets);
-		
-		return array($droplets, $new_droplets); 
+		self::add_metadata($droplets);		
 	}
 	
 	/**
@@ -1530,6 +1528,10 @@ class Model_Droplet extends ORM {
 
 		if ($user_orm->loaded())
 		{
+			// Get the current date
+			$today = new DateTime(date('Y-m-d'));
+			$start_date = $today->sub(new DateInterval('P14D'));
+
 			// Sanity check for the page number
 			$page = (empty($page)) ? 1 : $page;
 
@@ -1547,8 +1549,8 @@ class Model_Droplet extends ORM {
 			    ->on('all_scores.droplet_id', '=', 'droplets.id')
 			    ->join(array('droplet_scores', 'user_scores'), 'LEFT')
 			    ->on('user_scores.droplet_id', '=', DB::expr('droplets.id AND user_scores.user_id = '.$user_id))
-			    ->where('droplets.processing_status', '=', Model_Droplet::PROCESSING_STATUS_COMPLETE)
-			    ->where('droplets.parent_id', '=', 0);
+			    ->where('droplets.parent_id', '=', 0)
+			    ->where('droplets.droplet_date_add', '>=', $start_date->format('Y-m-d H:i:s'));
 
 			self::apply_droplets_filter($query, $filters, $user_id);
 

--- a/application/classes/model/river.php
+++ b/application/classes/model/river.php
@@ -301,9 +301,8 @@ class Model_River extends ORM {
 			    ->on('rivers_droplets.droplet_id', '=', 'droplets.id')
 			    ->join('identities', 'INNER')
 			    ->on('droplets.identity_id', '=', 'identities.id')
-				->where('rivers_droplets.droplet_date_pub', '>', '0000-00-00 00:00:00')
-			    ->where('rivers_droplets.river_id', '=', $river_id)
-			    ->where('droplets.processing_status', '=', Model_Droplet::PROCESSING_STATUS_COMPLETE);
+			    ->where('rivers_droplets.droplet_date_pub', '>', '0000-00-00 00:00:00')
+			    ->where('rivers_droplets.river_id', '=', $river_id);
 			
 			if ($drop_id)
 			{
@@ -404,7 +403,6 @@ class Model_River extends ORM {
 			    ->on('rivers_droplets.droplet_id', '=', 'droplets.id')
 			    ->join('identities', 'INNER')
 			    ->on('droplets.identity_id', '=', 'identities.id')
-			    ->where('droplets.processing_status', '=', Model_Droplet::PROCESSING_STATUS_COMPLETE)
 			    ->where('rivers_droplets.river_id', '=', $river_id)
 			    ->where('rivers_droplets.id', '>', $since_id);
 			


### PR DESCRIPTION
- The drop api doesn't return the list of newly added drops. Only the
  status code is returned; 200 on success 500 or 4xx otherwise
- Purge the cache whenever there's a change in the user's rivers or
  bucket listing; user accepts collaboration invite, creates/deletes a
  river/bucket
- Limit the general drop search to the last 14 days
