### PR TITLE
Add hook for the bucket settings navgiation

### DIFF
--- a/application/classes/model/droplet.php
+++ b/application/classes/model/droplet.php
@@ -1333,6 +1333,9 @@ class Model_Droplet extends ORM {
 			if ($bucket_orm->loaded())
 			{
 				$this->add('buckets', $bucket_orm);
+
+				$event_data = array('droplet_id' => $this->id, 'bucket_id' => $bucket_orm->id);
+				Swiftriver_Event::run('swiftriver.bucket.droplet.add', $event_data);
 			}
 		}
 		
@@ -1349,6 +1352,9 @@ class Model_Droplet extends ORM {
 			if ($this->has('buckets', $bucket_orm))
 			{
 				$this->remove('buckets', $bucket_orm);
+
+				$event_data = array('droplet_id' => $this->id, 'bucket_id' => $bucket_orm->id);
+				Swiftriver_Event::run('swiftriver.bucket.droplet.remove', $event_data);
 			}
 		}
 

--- a/themes/default/media/css/less/styles.less
+++ b/themes/default/media/css/less/styles.less
@@ -1733,6 +1733,10 @@ select.boolean-operator {
    margin: 13px 10px 13px 0;
 }
 
+#content.user article.container header .actions {
+  padding: 13px 10px;
+}
+
 #content.user section.property-parameters div.activity-item span.icon {
    float: left;
    padding: 0;

--- a/themes/default/media/css/styles.css
+++ b/themes/default/media/css/styles.css
@@ -1445,6 +1445,9 @@ select.boolean-operator {
 #content.user article.container a.remove-large {
   margin: 13px 10px 13px 0;
 }
+#content.user article.container header .actions {
+  padding: 13px 10px;
+}
 #content.user section.property-parameters div.activity-item span.icon {
   float: left;
   padding: 0;

--- a/themes/default/views/pages/bucket/settings/layout.php
+++ b/themes/default/views/pages/bucket/settings/layout.php
@@ -24,6 +24,11 @@
 				<li class="touchcarousel-item <?php if ($active == 'display' OR ! $active) echo 'active'; ?>">
 					<a href="<?php echo $bucket_base_url.'/settings/display'; ?>"><?php echo __("Display"); ?></a>
 				</li>
+				<?php
+					// Add bucket settings nav item
+					$event_params = array($bucket_base_url, $active);
+					Swiftriver_Event::run("swiftriver.bucket.settings.nav", $event_params);
+				?>
 			</ul>
 		</div>
 	</div>

--- a/themes/default/views/pages/river/settings/channels.php
+++ b/themes/default/views/pages/river/settings/channels.php
@@ -2,7 +2,7 @@
 	<div class="center">
 		<div class="col_12">
 			<div class="settings-toolbar">
-				<p class="button-blue button-small create"><a href="/markup/modal-channels.php" class="modal-trigger"><span class="icon"></span>Add channels</a></p>
+				<p class="button-blue button-small create"><a href="#" class="modal-trigger"><span class="icon"></span>Add channels</a></p>
 			</div>
 
 			<div class="alert-message blue" style="display:none;">

--- a/themes/default/views/pages/user/layout.php
+++ b/themes/default/views/pages/user/layout.php
@@ -34,7 +34,7 @@
 </nav>
 <?php endif; ?>
 
-<div id="content" class="user <?php echo $view_type ;?> cf">
+<div id="content" class="<?php echo $view_type ;?> cf">
 	<div class="center">
 		<?php echo $sub_content; ?>
 	</div>

--- a/themes/default/views/pages/user/layout.php
+++ b/themes/default/views/pages/user/layout.php
@@ -34,7 +34,7 @@
 </nav>
 <?php endif; ?>
 
-<div id="content" class="<?php echo $view_type ;?> cf">
+<div id="content" class="user <?php echo $view_type ;?> cf">
 	<div class="center">
 		<?php echo $sub_content; ?>
 	</div>


### PR DESCRIPTION
- The hook allows plugins to add navigations links on the settings
  navigation toolbar by introducing a new event: `swiftriver.bucket.settings.nav` Staging for #26
- We pass off an array with the `$bucket_base_url` and `$active` as the event data. This allows the plugins that hook into this event to access the URL of the bucket and also enables them manipulate the value of `$active`
