### PR TITLE
Add coordinates and place hash to place metadata

### DIFF
--- a/application/classes/model/droplet.php
+++ b/application/classes/model/droplet.php
@@ -1212,7 +1212,8 @@ class Model_Droplet extends ORM {
 		}
 		
 		//Query account links belonging to the selected droplet IDs
-		$query_account = DB::select('droplet_id', array('place_id', 'id'), 'place_name', 'place_name_canonical')
+		$query_account = DB::select('droplet_id', array('place_id', 'id'), 'place_name', 'place_name_canonical',
+				array('places.hash', 'place_hash'), 'latitude', 'longitude')
 					->from('account_droplet_places')
 					->join('places', 'INNER')
 					->on('places.id', '=', 'place_id')
@@ -1228,7 +1229,8 @@ class Model_Droplet extends ORM {
 		    ->where('deleted', '=', 1);
 
 		//Query all places belonging to the selected droplet IDs
-		$query_places = DB::select('droplet_id', array('place_id', 'id'), 'place_name', 'place_name_canonical')
+		$query_places = DB::select('droplet_id', array('place_id', 'id'), 'place_name', 'place_name_canonical',
+			array('places.hash', 'place_hash'), 'latitude', 'longitude')
 					->union($query_account, TRUE)
 					->from('droplets_places')
 					->join('places', 'INNER')


### PR DESCRIPTION
- Model_Droplet::populate_places is invoked by the plugin that
  implements #26. The additional info is necessary so that drops can be
  visualized and also so that we don't create duplicate (place/location)
  entries in Ushahidi
