### PR TITLE
Fix to update quota usage when river is deleted.

### DIFF
--- a/application/classes/controller/river.php
+++ b/application/classes/controller/river.php
@@ -184,12 +184,18 @@ class Controller_River extends Controller_Drop_Base {
 			$expiry_notice = View::factory('pages/river/expiry_notice');
 			$expiry_notice->river_base_url = $this->river_base_url."/extend";
 			$expiry_notice->extension_period = Model_Setting::get_setting('default_river_lifetime');
-			$this->droplets_view->expiry_notice = $expiry_notice;
+			$this->droplets_view->river_notice = $expiry_notice;
+
+		}
+		elseif ($this->owner AND $this->river->is_full())
+		{
+			$this->droplets_view->nothing_to_display = "";
+			$this->droplets_view->river_notice = View::factory('pages/river/full_notice');
 
 		}
 		else
 		{
-			$this->droplets_view->expiry_notice = '';
+			$this->droplets_view->river_notice = '';
 			$this->droplets_view->nothing_to_display = View::factory('pages/river/nothing_to_display')
 			    ->bind('anonymous', $this->anonymous);
 			$this->droplets_view->nothing_to_display->river_url = $this->request->url(TRUE);

--- a/application/classes/model/channel/filter.php
+++ b/application/classes/model/channel/filter.php
@@ -232,4 +232,25 @@ class Model_Channel_Filter extends ORM {
 			$filter_option->delete();
 		}
 	}
+	
+	/**
+	 * Get the total quota usage of the channel options in this channel
+	 *
+	 * @return array
+	 */
+	public function get_quota_usage() {
+		$quota_usage = array();
+			
+		$options = $this->channel_filter_options->find_all();		
+		foreach ($options as $option)
+		{
+			if ( ! isset($quota_usage[$option->key]))
+			{
+				$quota_usage[$option->key] = 0;
+			}
+			$quota_usage[$option->key] += $option->get_quota_usage();
+		}
+		
+		return $quota_usage;
+	}
 }

--- a/application/classes/model/channel/filter/option.php
+++ b/application/classes/model/channel/filter/option.php
@@ -96,6 +96,22 @@ class Model_Channel_Filter_Option extends ORM {
 		// Delete the filter option
 		parent::delete();
 	}
+	
+	/**
+	 * Get the quota usage of the channel option
+	 *
+	 * @return int
+	 */
+	public function get_quota_usage() {
+		$quota_usage = 0;
+		$option_data = json_decode($this->value, TRUE);
+		if (isset($option_data['quota_usage']))
+		{
+			$account_id = $this->channel_filter->river->account->id;
+			$quota_usage += (int)$option_data['quota_usage'];
+		}
+		return $quota_usage;
+	}
 
 	/**
 	 * Parses the "value" column of the channel filter option and returns it 

--- a/application/classes/model/river.php
+++ b/application/classes/model/river.php
@@ -851,6 +851,17 @@ class Model_River extends ORM {
 		return FALSE;
 	}
 	
+	
+	/**
+	 * Checks if the current river is full
+	 *
+	 * @return bool
+	 */
+	public function is_full()
+	{
+		return (bool)$this->river_full;
+	}
+	
 	/**
 	 * Returns whether a river expiry notification has been sent
 	 *

--- a/themes/default/media/js/assets.js
+++ b/themes/default/media/js/assets.js
@@ -113,11 +113,18 @@
 		deleteAsset: function() {
 			var message = 'Delete <a href="#">' + this.model.get('display_name') + "</a>?";
 			new ConfirmationWindow(message, function() {
-				message = '<a href="#">' + this.model.get('display_name') + "</a> has been deleted.";
-				this.model.destroy();
-				showConfirmationMessage(message);
-				this.$el.fadeOut("slow", function () {
-					$(this).remove();
+				asset = this;
+				this.model.destroy({
+					success: function() {
+						message = '<a href="#">' + asset.model.get('display_name') + "</a> has been deleted.";
+						showConfirmationMessage(message);
+						asset.$el.fadeOut("slow", function () {
+							$(this).remove();
+						});
+					},
+					error: function() {
+						showConfirmationMessage('Oops, unable to delete <a href="#">' + asset.model.get('display_name') + "</a>. Try again later.");
+					}
 				});
 			}, this).show();
 			return false;

--- a/themes/default/views/pages/drop/drops.php
+++ b/themes/default/views/pages/drop/drops.php
@@ -1,5 +1,5 @@
 <div id="content" class="river">
-<?php echo $expiry_notice; ?>
+<?php echo $river_notice; ?>
 </div>
 
 <script type="text/template" id="drop-listing-template">

--- a/themes/default/views/pages/river/full_notice.php
+++ b/themes/default/views/pages/river/full_notice.php
@@ -1,0 +1,9 @@
+<article class="river" id="system_notification">
+	<div class="center cf">
+		<article class="container base alert-message red">
+			<p>
+				<?php echo __("Your river is full and is no longer receiving drops from your channels."); ?>
+			</p>	
+		</article>
+	</div>
+</article>


### PR DESCRIPTION
- Currently deleting a river does not reduce the quota usage by the amount of quota used by all of the channels in the river.
- This commit corrects that omission by doing a quota update when the river is deleted.
