### PR TITLE
Allow empty channel option list

### DIFF
--- a/application/classes/swiftriver/plugins.php
+++ b/application/classes/swiftriver/plugins.php
@@ -203,7 +203,8 @@ class Swiftriver_Plugins {
 			$plugin_config = $config_plugins[$active_plugin->plugin_path];
 			if (isset($plugin_config['channel']) AND $plugin_config['channel'] == TRUE )
 			{
-				if ( ! ($channel_config = self::_validate_channel_plugin_config($plugin_config)))
+				$channel_config = self::_validate_channel_plugin_config($plugin_config);
+				if ( ! isset($channel_config))
 					continue;
 
 				self::$channels[] = array(
@@ -245,8 +246,8 @@ class Swiftriver_Plugins {
 	 *
 	 * @param array $plugin Plugin configuration
 	 * @param array $channel_config Channel config parameters to store
-	 * @return bool TRUE if the config for the channel plugin is in order, 
-	 *     FALSE otherwise
+	 * @return mixed array if the config for the channel plugin is in order, 
+	 *     NULL otherwise
 	 */
 	private static function _validate_channel_plugin_config($plugin)
 	{
@@ -256,7 +257,7 @@ class Swiftriver_Plugins {
 			Kohana::$log->add(Log::ERROR, ":plugin plugin config error. "
 			    . "'channel_options' MUST be an array.", array(':plugin' => $plugin['name']));
 			
-			return FALSE;
+			return NULL;
 		}
 		
 		foreach ($plugin['channel_options'] as $key =>  & $option)

--- a/themes/default/views/pages/river/settings/channels.php
+++ b/themes/default/views/pages/river/settings/channels.php
@@ -531,15 +531,20 @@ $(function() {
 		render: function() {
 			this.$el.html(this.template(this.model.toJSON()));
 			
-			// Populate the parameter list
-			var config = channelsConfig.getChannelConfig(this.model.get("channel"));
-			_.each(config.get("options"), function(option) {
-				var view = new ParameterView({model: option, channelView: this});
-				this.$("div.add-parameter ul").append(view.render().el);
-			}, this);
+			if (this.model.get('options').length) {
+				// Populate the parameter list
+				var config = channelsConfig.getChannelConfig(this.model.get("channel"));
+				_.each(config.get("options"), function(option) {
+					var view = new ParameterView({model: option, channelView: this});
+					this.$("div.add-parameter ul").append(view.render().el);
+				}, this);
 			
-			// Render channel options
-			this.channelOptions.each(this.addChannelOption, this);
+				// Render channel options
+				this.channelOptions.each(this.addChannelOption, this);
+			} else {
+				// Hide the 'Add parameter' button
+				this.$("div.add-parameter").hide();
+			}
 			
 			return this;	
 		},


### PR DESCRIPTION
Allows channels that don't require channel options like the SMS channel in the screen shot below to be added unambiguously

![](https://gist.github.com/raw/f28ceade9732895ad1d9/0b250d0a2e28fa200232fea72347688ece44ad09/wfSoop0bg1LladSo.png)
