### PR TITLE
Registration: Validate nickname is available before validating token

### DIFF
--- a/application/classes/controller/login.php
+++ b/application/classes/controller/login.php
@@ -341,7 +341,8 @@ class Controller_Login extends Controller_Swiftriver {
 			$post = Model_Auth_User::get_password_validation($this->request->post())
 									->rule('name', 'not_empty')
 									->rule('nickname', 'not_empty')
-									->rule('nickname', 'alpha_dash');
+									->rule('nickname', 'alpha_dash')
+									->rule('nickname', array('Model_Account', 'account_path_available'));
 									
 			if ( ! $post->check())
 			{
@@ -380,14 +381,6 @@ class Controller_Login extends Controller_Swiftriver {
 							$errors = array(__('Invalid email'));
 						}
 					}
-				}
-				
-				// Is the nickname taken?
-				$nickname = strtolower($this->request->post('nickname'));
-				$account = ORM::factory('account',array('account_path' => $nickname));
-				if ($account->loaded())
-				{
-					$errors = array(__('Nickname is already taken'));
 				}
 			}
 			

--- a/application/classes/model/account.php
+++ b/application/classes/model/account.php
@@ -212,4 +212,19 @@ class Model_Account extends ORM
 			$this->save();
 		}
 	}
+	
+	/**
+	 * Returns true if the given account path does not exist.
+	 *
+	 * @param string $account_path
+	 * @return boolean
+	 */	
+	public static function account_path_available($account_path)
+	{
+		$account = ORM::factory('Account',array(
+						'account_path' => strtolower($account_path))
+					);
+		
+		return !$account->loaded();		
+	}
 }

--- a/application/i18n/en.php
+++ b/application/i18n/en.php
@@ -2,4 +2,5 @@
 
 return array(
 	'login.password.invalid' => 'The username or password you entered is incorrect',
+	'user.nickname.account_path_available' => 'Nickname is already taken'
 );


### PR DESCRIPTION
Fixes #298 raised by @heatherleson 

Nickname validation was happening after registration token validation
and the latter is deleted when accessed. Thus if nickname validation
failed, another token would be required by restarting the entire
registration process.
