### PR TITLE
Change "url" references to "URL"

### DIFF
--- a/application/classes/Controller/Trend/Main.php
+++ b/application/classes/Controller/Trend/Main.php
@@ -131,7 +131,7 @@ class Controller_Trend_Main extends Controller_Swiftriver {
 				$this->bucket_base_url = $this->bucket->get_base_url();					
 				
 				$drops_url = URL::site().$this->bucket->account->account_path.'/bucket/'.$this->bucket->bucket_name_url;
-				$this->more_url = url::site().$this->account->account_path.'/bucket/'.$this->bucket->bucket_name_url.'/more';
+				$this->more_url = URL::site().$this->account->account_path.'/bucket/'.$this->bucket->bucket_name_url.'/more';
 				break;	    
 		}
 	

--- a/application/classes/Controller/User.php
+++ b/application/classes/Controller/User.php
@@ -428,7 +428,7 @@ class Controller_User extends Controller_Swiftriver {
 				$mail_body = View::factory('emails/changeemail')
 							 ->bind('secret_url', $secret_url);		            
         
-				$secret_url = url::site('login/changeemail/'.urlencode($this->user->email).'/'.urlencode($new_email).'/%token%', TRUE, TRUE);
+				$secret_url = URL::site('login/changeemail/'.urlencode($this->user->email).'/'.urlencode($new_email).'/%token%', TRUE, TRUE);
 				$site_email = Kohana::$config->load('site.email_address');
 				$mail_subject = __(':sitename: Email Change', array(':sitename' => Model_Setting::get_setting('site_name')));
 				$resp = RiverID_API::instance()

--- a/application/classes/Model/User.php
+++ b/application/classes/Model/User.php
@@ -504,7 +504,7 @@ class Model_User extends Model_Auth_User {
 			$mail_subject = __(':sitename: Please confirm your email address', 
 				array(':sitename' => Model_Setting::get_setting('site_name')));
 		}
-		$secret_url = url::site('login/create/'.urlencode($email).'/%token%', TRUE, TRUE);
+		$secret_url = URL::site('login/create/'.urlencode($email).'/%token%', TRUE, TRUE);
 		$site_email = Kohana::$config->load('site.email_address');
 		
 		$response = $riverid_api->request_password($email, $mail_body, $mail_subject, $site_email);
@@ -602,7 +602,7 @@ class Model_User extends Model_Auth_User {
 		$riverid_api = RiverID_API::instance();		            
 		$mail_body = View::factory('emails/resetpassword')
 					 ->bind('secret_url', $secret_url);		            
-		$secret_url = url::site('login/reset/'.urlencode($email).'/%token%', TRUE, TRUE);
+		$secret_url = URL::site('login/reset/'.urlencode($email).'/%token%', TRUE, TRUE);
 		$site_email = Kohana::$config->load('site.email_address');
 		$mail_subject = __(':sitename: Password Reset', array(':sitename' => Model_Setting::get_setting('site_name')));
 		$response = $riverid_api->request_password($email, $mail_body, $mail_subject, $site_email);
@@ -633,7 +633,7 @@ class Model_User extends Model_Auth_User {
 			//Send an email with a secret token URL
 			$mail_body = View::factory('emails/resetpassword')
 						 ->bind('secret_url', $secret_url);		            
-			$secret_url = url::site('login/reset/'.urlencode($email).'/'.$auth_token->token, TRUE, TRUE);
+			$secret_url = URL::site('login/reset/'.urlencode($email).'/'.$auth_token->token, TRUE, TRUE);
 			$mail_subject = __(':sitename: Password Reset', array(':sitename' => Model_Setting::get_setting('site_name')));
 			Swiftriver_Mail::send($email, $mail_subject, $mail_body);
 			

--- a/themes/default/views/template/header.php
+++ b/themes/default/views/template/header.php
@@ -8,7 +8,7 @@
 	<meta name="keywords" content="SwiftRiver">
 	<?php Swiftriver_Event::run('swiftriver.template.meta'); ?>
 	<link rel="index" title="SwiftRiver" href="<?php echo URL::base(TRUE,TRUE); ?>" /> 
-	<link rel="icon" href="<?php echo url::base(); ?>themes/default/media/img/favicon.png" type="image/png">
+	<link rel="icon" href="<?php echo URL::base(); ?>themes/default/media/img/favicon.png" type="image/png">
 	<?php
 	echo $meta; 
 	


### PR DESCRIPTION
- Users were unable to change their email or reset their
  password when the authentication backend is RiverID. This
  is because the class (Model_User) that generates the url for
  resetting the password was still referencing the url helper as
  "url" instead of "URL"after the Kohana 3.3 upgrade. Closes #308
